### PR TITLE
fix: app start error fixed

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,6 @@ load_dotenv()
 db = SQLAlchemy()
 migrate = Migrate()
 
-'''
 def create_app(config_name='development'):
     app = Flask(__name__)
 
@@ -65,6 +64,5 @@ def create_app(config_name='development'):
         }
 
     return app
-'''
 
 app = create_app()


### PR DESCRIPTION
create_app() is not defined error fixed.

The error was fixed eliminating `'''` which was wrapping the function.

Closes #2